### PR TITLE
fix: handle numeric search terms in clickstream

### DIFF
--- a/definitions/evaluation-clickstream.sqlx
+++ b/definitions/evaluation-clickstream.sqlx
@@ -17,14 +17,14 @@ USING (
       FORMAT_TIMESTAMP("%FT%TZ",TIMESTAMP_MICROS(ga.event_timestamp)) AS eventTime,
       item.item_id AS link,
       item_params.value.string_value as id,
-      (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'search_term') AS searchQuery
+      (SELECT COALESCE(value.string_value,SAFE_CAST(value.int_value AS STRING),SAFE_CAST(value.double_value AS STRING),SAFE_CAST(value.float_value AS STRING)) FROM UNNEST(event_params) WHERE key = 'search_term') AS searchQuery
     FROM `ga4-analytics-352613.analytics_330577055.events_*` ga,
       UNNEST(items) AS item,
       UNNEST(item.item_params) as item_params
     WHERE
       ga.event_name='select_item' AND
       item.item_list_name='Search' AND
-      (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'search_term') IS NOT NULL AND
+      (SELECT COALESCE(value.string_value,SAFE_CAST(value.int_value AS STRING),SAFE_CAST(value.double_value AS STRING),SAFE_CAST(value.float_value AS STRING)) FROM UNNEST(event_params) WHERE key = 'search_term') IS NOT NULL AND
       regexp_extract((SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), "order=([a-zA-Z\\\\-]+)" ) IS NULL AND
       ARRAY_TO_STRING(regexp_extract_all((SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), "((?:level_one_taxon|level_two_taxon|content_purpose_supergroup%5B%5D|public_timestamp%5Bfrom%5D|public_timestamp%5Bto%5D)=(?:%20&%20|[^&])*)" ), "&") ='' AND
       _TABLE_SUFFIX BETWEEN FORMAT_DATE('%Y%m%d',DATE_TRUNC(DATE_SUB(CURRENT_DATE(),INTERVAL 3 MONTH),MONTH)) AND FORMAT_DATE('%Y%m%d',DATE_TRUNC(CURRENT_DATE(),MONTH))


### PR DESCRIPTION
As with the "search" definition, include numeric search terms.
