### PR TITLE
refactor(sql): use GA4 flattened datasets

### DIFF
--- a/definitions/evaluation-clickstream.sqlx
+++ b/definitions/evaluation-clickstream.sqlx
@@ -10,25 +10,23 @@ USING (
   WITH 
   events AS (
     SELECT
-      CASE ga.user_pseudo_id
-        WHEN 'false' THEN CONCAT(ga.user_pseudo_id,(SELECT SAFE_CAST(value.int_value AS STRING) FROM UNNEST(event_params) WHERE key = 'ga_session_id'))
-        ELSE ga.user_pseudo_id
+      CASE user_pseudo_id
+        WHEN 'false' THEN CONCAT(user_pseudo_id, SAFE_CAST(ga_sessionid AS STRING))
+        ELSE user_pseudo_id
       END AS userPseudoId,
-      FORMAT_TIMESTAMP("%FT%TZ",TIMESTAMP_MICROS(ga.event_timestamp)) AS eventTime,
-      item.item_id AS link,
-      item_params.value.string_value as id,
-      (SELECT COALESCE(value.string_value,SAFE_CAST(value.int_value AS STRING),SAFE_CAST(value.double_value AS STRING),SAFE_CAST(value.float_value AS STRING)) FROM UNNEST(event_params) WHERE key = 'search_term') AS searchQuery
-    FROM `ga4-analytics-352613.analytics_330577055.events_*` ga,
-      UNNEST(items) AS item,
-      UNNEST(item.item_params) as item_params
+      FORMAT_TIMESTAMP("%FT%TZ",TIMESTAMP_MICROS(event_timestamp)) AS eventTime,
+      item_id AS link,
+      item_content_id as id,
+      search_term AS searchQuery
+    FROM `ga4-analytics-352613.flattened_dataset.partitioned_flattened_events`
     WHERE
-      ga.event_name='select_item' AND
-      item.item_list_name='Search' AND
-      (SELECT COALESCE(value.string_value,SAFE_CAST(value.int_value AS STRING),SAFE_CAST(value.double_value AS STRING),SAFE_CAST(value.float_value AS STRING)) FROM UNNEST(event_params) WHERE key = 'search_term') IS NOT NULL AND
-      regexp_extract((SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), "order=([a-zA-Z\\\\-]+)" ) IS NULL AND
-      ARRAY_TO_STRING(regexp_extract_all((SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), "((?:level_one_taxon|level_two_taxon|content_purpose_supergroup%5B%5D|public_timestamp%5Bfrom%5D|public_timestamp%5Bto%5D)=(?:%20&%20|[^&])*)" ), "&") ='' AND
-      _TABLE_SUFFIX BETWEEN FORMAT_DATE('%Y%m%d',DATE_TRUNC(DATE_SUB(CURRENT_DATE(),INTERVAL 3 MONTH),MONTH)) AND FORMAT_DATE('%Y%m%d',DATE_TRUNC(CURRENT_DATE(),MONTH))
-  ), 
+      event_name = 'select_item' AND
+      item_list_name = 'Search' AND
+      search_term IS NOT NULL AND
+      regexp_extract(page_location, "order=([a-zA-Z\\\\-]+)" ) IS NULL AND
+      ARRAY_TO_STRING(regexp_extract_all(page_location, "((?:level_one_taxon|level_two_taxon|content_purpose_supergroup%5B%5D|public_timestamp%5Bfrom%5D|public_timestamp%5Bto%5D)=(?:%20&%20|[^&])*)" ), "&") = '' AND
+      event_date BETWEEN DATE_TRUNC(DATE_SUB(CURRENT_DATE(),INTERVAL 3 MONTH),MONTH) AND DATE_TRUNC(CURRENT_DATE(),MONTH)
+  ),
   grouped AS (
     SELECT 
       MAX(events.searchQuery) AS query,


### PR DESCRIPTION
This is a spike to find out whether using the GA4 flattened datsets
instead of the raw GA4 data would be cheaper, and whether the dependency
would be justified.

The proposed refactoring of the `evaluation-clickstream` query would cost 0.2% of its current cost.

![image](https://github.com/user-attachments/assets/b6419644-2233-4f06-b217-b05e91eabddf)

## Queries to be refactored.

The following queries use the raw GA4 data.
```
definitions/search-intraday.sqlx
61:    `ga4-analytics-352613.analytics_330577055.events_intraday_*` ga,

definitions/view-item.sqlx
25:    `ga4-analytics-352613.analytics_330577055.events_*` ga,

definitions/view-item-intraday.sqlx
25:    `ga4-analytics-352613.analytics_330577055.events_intraday_*` ga,

definitions/evaluation-clickstream.sqlx
21:    FROM `ga4-analytics-352613.analytics_330577055.events_*` ga,

definitions/view-item-external-link.sqlx
25:    `ga4-analytics-352613.analytics_330577055.events_*` ga

definitions/search.sqlx
61:      `ga4-analytics-352613.analytics_330577055.events_*` ga,

definitions/evaluation-binary.sqlx
21:    FROM `ga4-analytics-352613.analytics_330577055.events_*` ga,

definitions/view-item-external-link-intraday.sqlx
35:    `ga4-analytics-352613.analytics_330577055.events_intraday_*` ga
```

## Test equivalence

The query `evaluation-clickstream` is used in this example.

The following CTE is the part of the query that would be refactored.

```sql
    SELECT DISTINCT -- DISTINCT because this CTE only has one-second timestamp resolution, so can have duplicates.
      CASE ga.user_pseudo_id
        WHEN 'false' THEN CONCAT(ga.user_pseudo_id,(SELECT SAFE_CAST(value.int_value AS STRING) FROM UNNEST(event_params) WHERE key = 'ga_session_id'))
        ELSE ga.user_pseudo_id
      END AS userPseudoId,
      FORMAT_TIMESTAMP("%FT%TZ",TIMESTAMP_MICROS(ga.event_timestamp)) AS eventTime,
      item.item_id AS link,
      item_params.value.string_value as id,
      (SELECT COALESCE(value.string_value,SAFE_CAST(value.int_value AS STRING),SAFE_CAST(value.double_value AS STRING),SAFE_CAST(value.float_value AS STRING)) FROM UNNEST(event_params) WHERE key = 'search_term') AS searchQuery
    FROM `ga4-analytics-352613.analytics_330577055.events_*` ga,
      UNNEST(items) AS item,
      UNNEST(item.item_params) as item_params
    WHERE
      ga.event_name='select_item' AND
      item.item_list_name='Search' AND
      (SELECT COALESCE(value.string_value,SAFE_CAST(value.int_value AS STRING),SAFE_CAST(value.double_value AS STRING),SAFE_CAST(value.float_value AS STRING)) FROM UNNEST(event_params) WHERE key = 'search_term') IS NOT NULL AND
      regexp_extract((SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), "order=([a-zA-Z\\\\-]+)" ) IS NULL AND
      ARRAY_TO_STRING(regexp_extract_all((SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), "((?:level_one_taxon|level_two_taxon|content_purpose_supergroup%5B%5D|public_timestamp%5Bfrom%5D|public_timestamp%5Bto%5D)=(?:%20&%20|[^&])*)" ), "&") =''
```

Define this CTE in a new query, alongside its proposed refactoring. Join the CTEs by all their columns, to check that neither has any rows that aren't in the other. Use `DISTINCT` in each CTE to deal with duplicates that can arise because the `event_timestamp` doesn't have sub-second resolution.

```sql
WITH original AS (
    SELECT DISTINCT -- DISTINCT because this CTE only has one-second timestamp resolution, so can have duplicates.
      CASE ga.user_pseudo_id
        WHEN 'false' THEN CONCAT(ga.user_pseudo_id,(SELECT SAFE_CAST(value.int_value AS STRING) FROM UNNEST(event_params) WHERE key = 'ga_session_id'))
        ELSE ga.user_pseudo_id
      END AS userPseudoId,
      FORMAT_TIMESTAMP("%FT%TZ",TIMESTAMP_MICROS(ga.event_timestamp)) AS eventTime,
      item.item_id AS link,
      item_params.value.string_value as id,
      (SELECT COALESCE(value.string_value,SAFE_CAST(value.int_value AS STRING),SAFE_CAST(value.double_value AS STRING),SAFE_CAST(value.float_value AS STRING)) FROM UNNEST(event_params) WHERE key = 'search_term') AS searchQuery
    FROM `ga4-analytics-352613.analytics_330577055.events_*` ga,
      UNNEST(items) AS item,
      UNNEST(item.item_params) as item_params
    WHERE
      ga.event_name='select_item' AND
      item.item_list_name='Search' AND
      (SELECT COALESCE(value.string_value,SAFE_CAST(value.int_value AS STRING),SAFE_CAST(value.double_value AS STRING),SAFE_CAST(value.float_value AS STRING)) FROM UNNEST(event_params) WHERE key = 'search_term') IS NOT NULL AND
      regexp_extract((SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), "order=([a-zA-Z\\\\-]+)" ) IS NULL AND
      ARRAY_TO_STRING(regexp_extract_all((SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), "((?:level_one_taxon|level_two_taxon|content_purpose_supergroup%5B%5D|public_timestamp%5Bfrom%5D|public_timestamp%5Bto%5D)=(?:%20&%20|[^&])*)" ), "&") ='' AND
      _TABLE_SUFFIX = FORMAT_DATE('%Y%m%d',DATE_TRUNC(CURRENT_DATE(),MONTH))
),
replacement AS (
  SELECT DISTINCT -- DISTINCT because this CTE only has one-second timestamp resolution, so can have duplicates.
    CASE user_pseudo_id
      WHEN 'false' THEN CONCAT(user_pseudo_id, SAFE_CAST(ga_sessionid AS STRING))
      ELSE user_pseudo_id
    END AS userPseudoId,
    FORMAT_TIMESTAMP("%FT%TZ",TIMESTAMP_MICROS(event_timestamp)) AS eventTime,
    item_id AS link,
    item_content_id as id,
    search_term AS searchQuery
  FROM `ga4-analytics-352613.flattened_dataset.partitioned_flattened_events`
  WHERE
    event_name = 'select_item' AND
    item_list_name = 'Search' AND
    search_term IS NOT NULL AND
    regexp_extract(page_location, "order=([a-zA-Z\\\\-]+)" ) IS NULL AND
    ARRAY_TO_STRING(regexp_extract_all(page_location, "((?:level_one_taxon|level_two_taxon|content_purpose_supergroup%5B%5D|public_timestamp%5Bfrom%5D|public_timestamp%5Bto%5D)=(?:%20&%20|[^&])*)" ), "&") = '' AND
    event_date = DATE_TRUNC(CURRENT_DATE(),MONTH)
)

-- Uncomment each of the following blocks in turn.

-- Either check that the `original` CTE has no rows that aren't also in `replacement`.
-- SELECT DISTINCT * from original
-- LEFT JOIN replacement USING (userPseudoId, eventTime, link, id, searchQuery)
-- WHERE replacement.eventTime IS NULL

-- Or check that the `replacement` CTE has no rows that aren't also in `original`.
-- SELECT DISTINCT * from replacement
-- LEFT JOIN original USING (userPseudoId, eventTime, link, id, searchQuery)
-- WHERE original.eventTime IS NULL
```

## Estimate current cost

34 TiB (about 214 USD) for the first 19 days of June.

BigQuery records the cost of each query that has been executed.

```sql
SELECT
  query,
  COUNT(query) AS n,
  SUM(total_bytes_billed) / POW(2, 40) AS total_tib_billed,
  6.25 * SUM(total_bytes_billed) / POW(2, 40) AS dollars
FROM
  `region-europe-west2`.INFORMATION_SCHEMA.JOBS
WHERE
  creation_time BETWEEN "2025-06-01"
  AND "2025-06-19"
  AND project_id = "search-api-v2-production"
  AND job_type = "QUERY"
  AND statement_type = "MERGE"
  AND query LIKE "%ga4-analytics-352613.analytics_330577055%"
  AND USER_EMAIL IN ("<Dataform default service account>", "<Analytics Pipeline Service Account>") -- use the email addresses of the actual service accounts
GROUP BY
  query
ORDER BY
  total_tib_billed DESC ;
```

query | number_of_executions | total_tib_billed | dollars
-- | -- | -- | --
... | 72 | 18.98646259 | 118.6653912
... | 18 | 6.104466438 | 38.15291524
... | 72 | 2.976037979 | 18.60023737
... | 1 | 1.992189407 | 12.4511838
... | 1 | 1.978691101 | 12.36681938
... | 18 | 1.141983986 | 7.137399912
... | 72 | 0.826675415 | 5.166721344
... | 18 | 0.3696632385 | 2.310395241

## Compare cost with prosed refactor

1. Paste the original CTE into BigQuery Studio to estimate the cost: 14.23 GB.

```sql
    SELECT DISTINCT -- DISTINCT because this CTE only has one-second timestamp resolution, so can have duplicates.
      CASE ga.user_pseudo_id
        WHEN 'false' THEN CONCAT(ga.user_pseudo_id,(SELECT SAFE_CAST(value.int_value AS STRING) FROM UNNEST(event_params) WHERE key = 'ga_session_id'))
        ELSE ga.user_pseudo_id
      END AS userPseudoId,
      FORMAT_TIMESTAMP("%FT%TZ",TIMESTAMP_MICROS(ga.event_timestamp)) AS eventTime,
      item.item_id AS link,
      item_params.value.string_value as id,
      (SELECT COALESCE(value.string_value,SAFE_CAST(value.int_value AS STRING),SAFE_CAST(value.double_value AS STRING),SAFE_CAST(value.float_value AS STRING)) FROM UNNEST(event_params) WHERE key = 'search_term') AS searchQuery
    FROM `ga4-analytics-352613.analytics_330577055.events_*` ga,
      UNNEST(items) AS item,
      UNNEST(item.item_params) as item_params
    WHERE
      ga.event_name='select_item' AND
      item.item_list_name='Search' AND
      (SELECT COALESCE(value.string_value,SAFE_CAST(value.int_value AS STRING),SAFE_CAST(value.double_value AS STRING),SAFE_CAST(value.float_value AS STRING)) FROM UNNEST(event_params) WHERE key = 'search_term') IS NOT NULL AND
      regexp_extract((SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), "order=([a-zA-Z\\\\-]+)" ) IS NULL AND
      ARRAY_TO_STRING(regexp_extract_all((SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), "((?:level_one_taxon|level_two_taxon|content_purpose_supergroup%5B%5D|public_timestamp%5Bfrom%5D|public_timestamp%5Bto%5D)=(?:%20&%20|[^&])*)" ), "&") ='' AND
      _TABLE_SUFFIX = FORMAT_DATE('%Y%m%d',DATE_TRUNC(CURRENT_DATE(),MONTH))
```

2. Paste the refactored CTE into BigQuery Studio to estimate the cost: 41.91 MB.

```sql
  SELECT DISTINCT -- DISTINCT because this CTE only has one-second timestamp resolution, so can have duplicates.
    CASE user_pseudo_id
      WHEN 'false' THEN CONCAT(user_pseudo_id, SAFE_CAST(ga_sessionid AS STRING))
      ELSE user_pseudo_id
    END AS userPseudoId,
    FORMAT_TIMESTAMP("%FT%TZ",TIMESTAMP_MICROS(event_timestamp)) AS eventTime,
    item_id AS link,
    item_content_id as id,
    search_term AS searchQuery
  FROM `ga4-analytics-352613.flattened_dataset.partitioned_flattened_events`
  WHERE
    event_name = 'select_item' AND
    item_list_name = 'Search' AND
    search_term IS NOT NULL AND
    regexp_extract(page_location, "order=([a-zA-Z\\\\-]+)" ) IS NULL AND
    ARRAY_TO_STRING(regexp_extract_all(page_location, "((?:level_one_taxon|level_two_taxon|content_purpose_supergroup%5B%5D|public_timestamp%5Bfrom%5D|public_timestamp%5Bto%5D)=(?:%20&%20|[^&])*)" ), "&") = '' AND
    event_date = DATE_TRUNC(CURRENT_DATE(),MONTH)
```