### PR TITLE
fix: use uri not path in explicit sample query set

### DIFF
--- a/definitions/evaluation-explicit.sqlx
+++ b/definitions/evaluation-explicit.sqlx
@@ -18,7 +18,7 @@ USING (
     query,
     ARRAY_AGG(
       STRUCT(
-        path AS uri,
+        uri,
         score
       ) ORDER BY score DESC
     ) AS targets


### PR DESCRIPTION
Evaluations of the explicit sample query set currently return empty, because the `uri` of each target is in fact the path (e.g. `/foo/bar` instead of the Content ID (a UUID). Because the evaluations are empty, a [rake task](https://github.com/alphagov/search-api-v2/blob/58c8c194a9e5f57ea22bf96e2c0553ca4a733a62/lib/tasks/quality.rake#L25) fails to upload them into Prometheus, which is where we noticed the problem.