### PR TITLE
fix: refresh entire partition of evaluation inputs

### DIFF
--- a/definitions/evaluation-binary.sqlx
+++ b/definitions/evaluation-binary.sqlx
@@ -5,9 +5,23 @@ config {
     tags: ["search-monthly"]
 }
 
-MERGE INTO `${dataform.projectConfig.vars.project_id}.automated_evaluation_input.binary` T
-USING (
-  WITH
+DECLARE
+  PARTITIONTIME TIMESTAMP;
+
+BEGIN TRANSACTION;
+
+SET
+  PARTITIONTIME = TIMESTAMP_TRUNC((CURRENT_TIMESTAMP()),MONTH);
+
+DELETE
+FROM
+  automated_evaluation_input.binary
+WHERE
+  _PARTITIONTIME = PARTITIONTIME;
+
+INSERT INTO automated_evaluation_input.binary (_PARTITIONTIME,
+    queryEntry)
+WITH
   events AS (
     SELECT
       CASE user_pseudo_id
@@ -68,7 +82,7 @@ USING (
     WHERE total>50
   )
   SELECT
-    TIMESTAMP_TRUNC((CURRENT_TIMESTAMP()),MONTH) AS _PARTITIONTIME,
+    PARTITIONTIME AS _PARTITIONTIME,
     STRUCT(
     query,
     ARRAY_AGG(
@@ -82,11 +96,6 @@ USING (
   WHERE score>2
   GROUP BY query
   ORDER BY MAX(total) DESC
-  LIMIT 1000) S
-ON
-  T._PARTITIONTIME = S._PARTITIONTIME AND
-  to_json_string(T.queryEntry) = to_json_string(S.queryEntry)
-  WHEN NOT MATCHED
-  THEN
-INSERT (_PARTITIONTIME, queryEntry)
-VALUES (_PARTITIONTIME, queryEntry)
+  LIMIT 1000;
+
+COMMIT TRANSACTION;

--- a/definitions/evaluation-clickstream.sqlx
+++ b/definitions/evaluation-clickstream.sqlx
@@ -5,8 +5,22 @@ config {
     tags: ["search-monthly"]
 }
 
-MERGE INTO `${dataform.projectConfig.vars.project_id}.automated_evaluation_input.clickstream` T
-USING (
+DECLARE
+  PARTITIONTIME TIMESTAMP;
+
+BEGIN TRANSACTION;
+
+SET
+  PARTITIONTIME = TIMESTAMP_TRUNC((CURRENT_TIMESTAMP()),MONTH);
+
+DELETE
+FROM
+  automated_evaluation_input.clickstream
+WHERE
+  _PARTITIONTIME = PARTITIONTIME;
+
+INSERT INTO automated_evaluation_input.clickstream (_PARTITIONTIME,
+    queryEntry)
   WITH
   events AS (
     SELECT
@@ -68,7 +82,7 @@ USING (
     WHERE total>50
   )
   SELECT
-    TIMESTAMP_TRUNC((CURRENT_TIMESTAMP()),MONTH) AS _PARTITIONTIME,
+    PARTITIONTIME AS _PARTITIONTIME,
     STRUCT(
     query,
     ARRAY_AGG(
@@ -82,11 +96,6 @@ USING (
   WHERE score>0
   GROUP BY query
   ORDER BY MAX(total) DESC
-  LIMIT 1000) S
-ON
-  T._PARTITIONTIME = S._PARTITIONTIME AND
-  to_json_string(T.queryEntry) = to_json_string(S.queryEntry)
-  WHEN NOT MATCHED
-  THEN
-INSERT (_PARTITIONTIME, queryEntry)
-VALUES (_PARTITIONTIME, queryEntry)
+  LIMIT 1000;
+
+COMMIT TRANSACTION;

--- a/definitions/evaluation-explicit.sqlx
+++ b/definitions/evaluation-explicit.sqlx
@@ -5,32 +5,42 @@ config {
     tags: ["search-monthly"]
 }
 
-MERGE INTO `automated_evaluation_input.explicit` T
-USING (
-  WITH 
-  source AS (
-    SELECT *
-    FROM `automated_evaluation_input.explicit_source`
+DECLARE
+  PARTITIONTIME TIMESTAMP;
+
+BEGIN TRANSACTION;
+
+SET
+  PARTITIONTIME = TIMESTAMP_TRUNC((CURRENT_TIMESTAMP()),MONTH);
+
+DELETE
+FROM
+  automated_evaluation_input.explicit
+WHERE
+  _PARTITIONTIME = PARTITIONTIME;
+
+INSERT INTO
+  automated_evaluation_input.explicit (
+    _PARTITIONTIME,
+    queryEntry
   )
-  SELECT
-    TIMESTAMP_TRUNC((CURRENT_TIMESTAMP()),MONTH) AS _PARTITIONTIME,
-    STRUCT(
+SELECT
+  PARTITIONTIME AS _PARTITIONTIME,
+  STRUCT(
     query,
     ARRAY_AGG(
       STRUCT(
         uri,
         score
-      ) ORDER BY score DESC
+      )
+      ORDER BY score DESC
     ) AS targets
-    ) AS queryEntry
-  FROM source
-  GROUP BY query
-  LIMIT 1000
-  ) S
-ON 
-  T._PARTITIONTIME = S._PARTITIONTIME AND
-  to_json_string(T.queryEntry) = to_json_string(S.queryEntry)
-  WHEN NOT MATCHED
-  THEN
-INSERT (_PARTITIONTIME, queryEntry)
-VALUES (_PARTITIONTIME, queryEntry)
+  ) AS queryEntry
+FROM
+  automated_evaluation_input.explicit_source
+GROUP BY
+  query
+LIMIT
+  1000;
+
+COMMIT TRANSACTION;


### PR DESCRIPTION
The queries that append a new month's data to the tables in the `automated_evaluation_input` dataset should wipe an existing partition of the same date, rather than merge into it. The present `MERGE` can't delete rows that should no longer be there, it can only appends rows that aren't already there.

Fixes #43