### PR TITLE
fix: missing content_id in view-item table

### DIFF
--- a/definitions/view-item.sqlx
+++ b/definitions/view-item.sqlx
@@ -17,11 +17,12 @@ USING
       ELSE user_pseudo_id
     END AS userPseudoId,
     FORMAT_TIMESTAMP("%FT%TZ",TIMESTAMP_MICROS(event_timestamp)) AS eventTime,
-    (CASE WHEN content_id IS NOT NULL THEN [STRUCT(content_id AS id, CAST(NULL AS string) AS name)] END) AS documents,
+    [STRUCT(content_id AS id, CAST(NULL AS string) AS name)] AS documents,
     FROM `ga4-analytics-352613.flattened_dataset.partitioned_flattened_events`
   WHERE
     event_date = DATE_TRUNC(DATE_SUB(CURRENT_DATE(),INTERVAL 1 DAY),DAY) AND
-    event_name='page_view' ) S
+    event_name='page_view' AND
+    content_id is not null ) S
 ON
   T._PARTITIONTIME = S._PARTITIONTIME
   AND T.eventType = S.eventType


### PR DESCRIPTION
Importing user events warns:

```
google.cloud.discoveryengine.v1.UserEventService.ImportUserEvents
MISSING_FIELD userEvent_documents
Field "userEvent.documents" is a required field, but no value is found.
```

Activity warning https://console.cloud.google.com/gen-app-builder/locations/global/engines/govuk_global/data/activities?project=search-api-v2-integration

Log query: `jsonPayload.status.message="Field \"userEvent.documents\" is a required field, but no value is found."`

This seems to have gone unnoticed for a long time, and probably occurred before the last time this query was edited.

The fix is to filter out views that don't have an associated content ID.
